### PR TITLE
Add in the downsampler in addition to decimator

### DIFF
--- a/stream/downsample.go
+++ b/stream/downsample.go
@@ -1,0 +1,126 @@
+// {{{ Copyright (c) Paul R. Tagliamonte <paul@k3xec.com>, 2021
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. }}}
+
+package stream
+
+import (
+	"hz.tools/sdr"
+)
+
+// DownsampleReader will take an oversampled input stream, and create a
+// downsampled output stream that increases the ENOB (effective number of
+// bits).
+//
+// For every 4 samples downsampled, you gain the equivalent of one bit of
+// precision. For instance, for an 8-bit ADC at 3 Megasamples per secnd
+// being downsampled, the following table outlines the ENOB and sample rate
+// depending on the factor.
+//
+// +---------+-------------+------+
+// | factor  | sample rate | ENOB |
+// +---------+-------------+------+
+// |      4  |      750000 |    9 |
+// +---------+-------------+------+
+// |      16 |      187500 |   10 |
+// +---------+-------------+------+
+// |      64 |       46875 |   11 |
+// +---------+-------------+------+
+// |     246 |       11718 |   12 |
+// +---------+-------------+------+
+//
+func DownsampleReader(in sdr.Reader, factor int) (sdr.Reader, error) {
+	var offset = 0
+
+	return ReadTransformer(in, ReadTransformerConfig{
+		InputBufferLength:  32 * 1024,
+		OutputBufferLength: 32 * 1024,
+		OutputSampleRate:   in.SampleRate() / uint32(factor),
+		OutputSampleFormat: sdr.SampleFormatC64,
+		Proc: func(inBuf sdr.Samples, outBuf sdr.Samples) (int, error) {
+			n, err := DownsampleBuffer(outBuf, inBuf, factor, offset)
+			offset += inBuf.Length()
+			return n, err
+		},
+	})
+}
+
+// DownsampleBuffer will take an oversampled input buffer, and write the
+// downsampled output samples to the target buffer.
+func DownsampleBuffer(to, from sdr.Samples, factor, offset int) (int, error) {
+	if to.Format() != sdr.SampleFormatC64 {
+		return 0, sdr.ErrSampleFormatMismatch
+	}
+
+	toLength := to.Length()
+	fromLength := from.Length()
+
+	if toLength < fromLength/factor {
+		return 0, sdr.ErrDstTooSmall
+	}
+
+	// TOMBSTONE FOR FUTURE HACKERS
+	//
+	// Here we don't use the generic sdr.Iq Interface because we need to
+	// both get and set at index offsets. THe Iq interface has enough for
+	// most copy/io operations (for both the sdr library and users), but
+	// in this case, we need to be doing some fairly detailed manipulation
+	// of the IQ data.
+	//
+	// This means if you add a new sample format, this particular code
+	// will need to become aware on how to get/set specific indexes.
+
+	var (
+		i   int
+		out = to.(sdr.SamplesC64)
+	)
+
+	for i = 0; i < fromLength/factor; i++ {
+		var (
+			start                  = i * factor
+			end                    = (i + 1) * factor
+			samples sdr.SamplesC64 = make(sdr.SamplesC64, factor)
+			sample  complex64
+		)
+
+		switch from := from.(type) {
+		case sdr.SamplesU8:
+			from[start:end].ToC64(samples)
+		case sdr.SamplesI16:
+			from[start:end].ToC64(samples)
+		case sdr.SamplesC64:
+			samples = from[start:end]
+		default:
+			return 0, sdr.ErrSampleFormatUnknown
+		}
+
+		for j := range samples {
+			sample += samples[j]
+		}
+
+		out[i] = complex64(complex(
+			real(sample)/float32(factor),
+			imag(sample)/float32(factor),
+		))
+	}
+
+	return int(i), nil
+}
+
+// vim: foldmethod=marker

--- a/stream/downsample_test.go
+++ b/stream/downsample_test.go
@@ -1,0 +1,94 @@
+// {{{ Copyright (c) Paul R. Tagliamonte <paul@k3xec.com>, 2020
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. }}}
+
+package stream_test
+
+import (
+	"sync"
+
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"hz.tools/sdr"
+	"hz.tools/sdr/stream"
+)
+
+func TestDownsampleCount(t *testing.T) {
+	pipeReader, pipeWriter := sdr.Pipe(10000, sdr.SampleFormatC64)
+
+	decReader, err := stream.DownsampleReader(pipeReader, 4)
+	assert.NoError(t, err)
+
+	inputBuffer := make(sdr.SamplesC64, 1000*8)
+	wg := sync.WaitGroup{}
+	go func() {
+		defer wg.Done()
+		outputBuffer := make(sdr.SamplesC64, 1000*8)
+		n, err := sdr.ReadFull(decReader, outputBuffer)
+		assert.Error(t, err)
+		assert.Equal(t, (1000*8)/4, n)
+	}()
+	wg.Add(1)
+
+	n, err := pipeWriter.Write(inputBuffer)
+	assert.NoError(t, err)
+	assert.Equal(t, 1000*8, n)
+	pipeWriter.Close()
+
+	wg.Wait()
+}
+
+func TestDownsampleCalc(t *testing.T) {
+	pipeReader, pipeWriter := sdr.Pipe(10000, sdr.SampleFormatC64)
+
+	decReader, err := stream.DownsampleReader(pipeReader, 4)
+	assert.NoError(t, err)
+
+	inputBuffer := make(sdr.SamplesC64, 1000*8)
+	wg := sync.WaitGroup{}
+	go func() {
+		defer wg.Done()
+		outputBuffer := make(sdr.SamplesC64, 1000*8)
+		n, err := sdr.ReadFull(decReader, outputBuffer)
+		assert.Error(t, err)
+		assert.Equal(t, (1000*8)/4, n)
+
+		outputBuffer = outputBuffer[:n]
+
+		for _, el := range outputBuffer {
+			assert.Equal(t, complex64(complex(1.5, 1.5)), el)
+		}
+	}()
+	wg.Add(1)
+
+	for i := range inputBuffer {
+		e := float32(i % 4)
+		inputBuffer[i] = complex64(complex(e, e))
+	}
+
+	n, err := pipeWriter.Write(inputBuffer)
+	assert.NoError(t, err)
+	assert.Equal(t, 1000*8, n)
+	pipeWriter.Close()
+
+	wg.Wait()
+}
+
+// vim: foldmethod=marker


### PR DESCRIPTION
This is useful when you want to oversample the input IQ stream, and
increase the output ENOB. While this isn't as good as having a higher
resolution ADC, it can't hurt!