### PR TITLE
Export SIMD helpers via bound functions on sdr.SamplesC64

### DIFF
--- a/iq_c64.go
+++ b/iq_c64.go
@@ -23,6 +23,8 @@ package sdr
 import (
 	"math"
 	"unsafe"
+
+	"hz.tools/sdr/internal/simd"
 )
 
 // SamplesC64 indicates that the samples are in a complex64
@@ -98,6 +100,19 @@ func (s SamplesC64) ToI16(out SamplesI16) error {
 		}
 	}
 	return nil
+}
+
+// Scale will multiply each I and Q value by the provided real value 'r'. This
+// will *not* do a complex multiplication, this is the same as if each phasor
+// had their real and imag parts multiplied by the provided real value 'r'.
+func (s SamplesC64) Scale(r float32) {
+	simd.ScaleComplex(r, s)
+}
+
+// Multiply will conduct a complex multiplication of each phasor in this buffer
+// by a provided complex number 'c'.
+func (s SamplesC64) Multiply(c complex64) {
+	simd.RotateComplex(c, s)
 }
 
 // vim: foldmethod=marker

--- a/iq_c64_test.go
+++ b/iq_c64_test.go
@@ -80,4 +80,27 @@ func TestConvertC64ToI16(t *testing.T) {
 	assert.Equal(t, [2]int16{0, 0}, i16Samples[0])
 }
 
+func TestC64Scale(t *testing.T) {
+	c64Samples := make(sdr.SamplesC64, 31)
+	for i := range c64Samples {
+		c64Samples[i] = complex64(complex(10, 10))
+	}
+	c64Samples.Scale(0.5)
+	for _, el := range c64Samples {
+		assert.Equal(t, float32(5), real(el))
+		assert.Equal(t, float32(5), imag(el))
+	}
+}
+
+func TestC64Multiply(t *testing.T) {
+	c64Samples := make(sdr.SamplesC64, 31)
+	for i := range c64Samples {
+		c64Samples[i] = complex64(complex(10, 10))
+	}
+	c64Samples.Multiply(complex(0.5, 0.5))
+	for _, el := range c64Samples {
+		assert.Equal(t, complex64(complex(0, 10)), el)
+	}
+}
+
 // vim: foldmethod=marker

--- a/stream/rotate.go
+++ b/stream/rotate.go
@@ -22,7 +22,6 @@ package stream
 
 import (
 	"hz.tools/sdr"
-	"hz.tools/sdr/internal/simd"
 )
 
 type multiplyReader struct {
@@ -54,7 +53,7 @@ func (mr *multiplyReader) Read(s sdr.Samples) (int, error) {
 	// TODO(paultag): Fix this to be safe when the above format checks
 	// grow.
 	sC64 := s.(sdr.SamplesC64)
-	simd.RotateComplex(mr.m, sC64)
+	sC64.Multiply(mr.m)
 	// vfor j := range sC64 {
 	// v	sC64[j] = sC64[j] * mr.m
 	// v}


### PR DESCRIPTION
Prior to this, there was no way for depending libraries to use the SIMD
optimized multiplication routines. Since exporting the raw SIMD library
is not something I want to support, two helpers have been exported on
the sdr.SamplesC64 type, one to multiply each I and Q value by a real,
and the second will do a complex multiplication/rotation.