### PR TITLE
The MultiWriter API was kludgey, refactoring

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -51,7 +51,9 @@ func TestMultiWriterU8(t *testing.T) {
 	buf[0][0] = 0xFF
 	buf[1][1] = 0xFF
 
-	mw := sdr.MultiWriter(0, sdr.SampleFormatU8, pipeWriter1, pipeWriter2)
+	mw, err := sdr.MultiWriter(pipeWriter1, pipeWriter2)
+	assert.NoError(t, err)
+
 	i, err := mw.Write(buf)
 	assert.NoError(t, err)
 	assert.Equal(t, 1024, i)


### PR DESCRIPTION
It's a lot of work to pull the SampleRate -- and it should be checked on
Write anyway. We'll do the check up on top and prevent runtime errors in
favor of a constructor error. This also reduces the argument count.

There are only a few MultiWriters around the codebase, so this is an
easy change to make right now.