### PR TITLE
Add in a sdr.Discard writer

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -144,4 +144,31 @@ func WriterWithCloser(w Writer, c func() error) WriteCloser {
 	}
 }
 
+type discard struct {
+	sampleFormat SampleFormat
+	sampleRate   uint
+}
+
+func (d discard) SampleFormat() SampleFormat {
+	return d.sampleFormat
+}
+
+func (d discard) SampleRate() uint {
+	return d.sampleRate
+}
+
+func (d discard) Write(s Samples) (int, error) {
+	return s.Length(), nil
+}
+
+// Discard will accept writes, and store them safely... nowhere. This is
+// a highly optimized and very fast writer. Just don't expect to get your
+// data back.
+func Discard(sampleRate uint, sampleFormat SampleFormat) Writer {
+	return discard{
+		sampleFormat: sampleFormat,
+		sampleRate:   sampleRate,
+	}
+}
+
 // vim: foldmethod=marker

--- a/writer_test.go
+++ b/writer_test.go
@@ -91,4 +91,19 @@ func TestWriterWithCloser(t *testing.T) {
 	assert.True(t, closeCalled)
 }
 
+func TestDiscard(t *testing.T) {
+	for _, sf := range map[string]sdr.SampleFormat{
+		"C64": sdr.SampleFormatC64,
+		"I16": sdr.SampleFormatI16,
+		"U8":  sdr.SampleFormatU8,
+	} {
+		w := sdr.Discard(0, sdr.SampleFormatC64)
+		b, err := sdr.MakeSamples(sf, 1024*32)
+		assert.NoError(t, err)
+		i, err := w.Write(b)
+		assert.NoError(t, err)
+		assert.Equal(t, 1024*32, i)
+	}
+}
+
 // vim: foldmethod=marker


### PR DESCRIPTION
This can be used to sink Writes into without having to open some sort of
writer.