### PR TITLE
Add in the HackRF driver to mainline.

### DIFF
--- a/hackrf/README.md
+++ b/hackrf/README.md
@@ -1,0 +1,10 @@
+# HackRF hz.tools/sdr driver
+
+The HackRF driver was one of the early drivers originally written in early
+2020, but it was removed in Jan of 2021, and rewritten in March 2021.
+
+|-------------|----|
+| Format Type | I8 |
+| Receiver    | ✓  |
+| Transmitter | ✓  |
+

--- a/hackrf/gains.go
+++ b/hackrf/gains.go
@@ -1,0 +1,302 @@
+// {{{ Copyright (c) Paul R. Tagliamonte <paul@k3xec.com>, 2020-2021
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. }}}
+
+package hackrf
+
+// #cgo linux LDFLAGS: -lhackrf
+//
+// #include <libhackrf/hackrf.h>
+import "C"
+
+import (
+	"fmt"
+
+	"hz.tools/sdr"
+)
+
+// GetGainStages implements the sdr.Sdr interface.
+func (s *Sdr) GetGainStages() (sdr.GainStages, error) {
+	ret := sdr.GainStages{
+		// TODO(paultag): is 14 right?
+		ampGain(newSteppedGain(
+			"Amp",
+			sdr.GainStageTypeRecieve|sdr.GainStageTypeTransmit|sdr.GainStageTypeFE|sdr.GainStageTypeAmp,
+			0, 14, 14,
+		)),
+		ifGain(newSteppedGain("RXIF", sdr.GainStageTypeRecieve|sdr.GainStageTypeIF, 0, 40, 8)),
+		vgaRxGain(newSteppedGain("RXVGA", sdr.GainStageTypeRecieve|sdr.GainStageTypeBB, 0, 62, 2)),
+		vgaTxGain(newSteppedGain("TXVGA", sdr.GainStageTypeTransmit|sdr.GainStageTypeBB, 0, 47, 1)),
+	}
+
+	return ret, nil
+}
+
+// GetGain implements the sdr.Sdr interface.
+func (s *Sdr) GetGain(stage sdr.GainStage) (float32, error) {
+	return 0, sdr.ErrNotSupported
+}
+
+// SetGain implements the sdr.Sdr interface.
+func (s *Sdr) SetGain(gainStage sdr.GainStage, gain float32) error {
+	stage, ok := gainStage.(hackrfGainStage)
+	if !ok {
+		return fmt.Errorf("hackrf: unknown GainStage")
+	}
+	return stage.SetGain(s, gain)
+}
+
+// hackrfGainStage is implemented by both gain stages in order to set the
+// Gain on the HackRF
+type hackrfGainStage interface {
+	// SetGain will set the gain on the specified Stage.
+	SetGain(*Sdr, float32) error
+
+	// SetGain will get the gain on the specified Stage.
+	GetGain(*Sdr) (float32, error)
+}
+
+//
+// The actual sdr.GainStage implementions are below this marker. They're
+// both derived from the steppedGain object, and will do their best to
+// pick sensible gain values for the underlying dongle.
+//
+
+// steppedGain is the internal base type that we're using to define
+// Tuner and IF gain, since they're both clamped to fixed values.
+type steppedGain struct {
+	Name           string
+	supportedGains []uint32
+	gainType       sdr.GainStageType
+}
+
+func newSteppedGain(name string, gainType sdr.GainStageType, low, high, step uint32) steppedGain {
+	gains := []uint32{}
+	var i uint32 = low
+	for ; i <= high; i = i + step {
+		gains = append(gains, i)
+	}
+	return steppedGain{
+		Name:           name,
+		supportedGains: gains,
+		gainType:       gainType,
+	}
+}
+
+// GetGainSteps implements the unspoken "steppable" Gain interface.
+func (stg steppedGain) GetGainSteps() []float32 {
+	ret := []float32{}
+	for _, gain := range stg.supportedGains {
+		ret = append(ret, float32(gain))
+	}
+	return ret
+}
+
+// nearestGain will return the nearest gain step to the requested
+// gain step, all in hackrf gain increments.
+func (stg steppedGain) nearestGain(fGain float32) uint32 {
+	var (
+		gainStep         uint32 = 0
+		gainStepDistance int32  = -1
+	)
+
+	// TODO(paultag): use math.Round
+	gain := int32(fGain)
+
+	for _, gainValue := range stg.supportedGains {
+		gainDistance := gain - int32(gainValue)
+		if gainDistance < 0 {
+			gainDistance = -gainDistance
+		}
+		// We have the abs distance from our step to the target Gain, and now
+		// we'll check to see if we're closer or further than the current
+		// distance.
+
+		if gainDistance < gainStepDistance || gainStepDistance < 0 {
+			gainStepDistance = gainDistance
+			gainStep = gainValue
+		}
+	}
+
+	return gainStep
+}
+
+// String implements the sdr.GainStage interface.
+func (stg steppedGain) String() string {
+	return stg.Name
+}
+
+// Type implements the sdr.GainStage interface.
+func (stg steppedGain) Type() sdr.GainStageType {
+	return stg.gainType
+}
+
+// Rage implements the sdr.GainStage interface.
+func (stg steppedGain) Range() [2]float32 {
+	sglen := len(stg.supportedGains)
+	if sglen < 2 {
+		return [2]float32{0, 0}
+	}
+	return [2]float32{
+		float32(stg.supportedGains[0]),
+		float32(stg.supportedGains[sglen-1]),
+	}
+}
+
+// vgaRxGain
+type vgaRxGain steppedGain
+
+// Type implements the sdr.GainStage interface.
+func (tg vgaRxGain) Type() sdr.GainStageType {
+	return steppedGain(tg).Type()
+}
+
+// Range implements the sdr.GainStage interface.
+func (tg vgaRxGain) Range() [2]float32 {
+	return steppedGain(tg).Range()
+}
+
+// Get the gain steps that we support.
+func (tg vgaRxGain) GetGainSteps() []float32 {
+	return steppedGain(tg).GetGainSteps()
+}
+
+// String implements the sdr.GainStage interface.
+func (tg vgaRxGain) String() string {
+	return steppedGain(tg).String()
+}
+
+// SetGain implements the internal hackrfGain interface.
+func (tg vgaRxGain) SetGain(s *Sdr, gain float32) error {
+	hackrfGain := C.uint32_t(steppedGain(tg).nearestGain(gain))
+	return rvToErr(C.hackrf_set_vga_gain(s.dev, hackrfGain))
+}
+
+// GetGain implements the internal hackrfGain interface.
+func (tg vgaRxGain) GetGain(s *Sdr) (float32, error) {
+	return 0, sdr.ErrNotSupported
+}
+
+// vgaTxGain
+type vgaTxGain steppedGain
+
+// Type implements the sdr.GainStage interface.
+func (tg vgaTxGain) Type() sdr.GainStageType {
+	return steppedGain(tg).Type()
+}
+
+// Range implements the sdr.GainStage interface.
+func (tg vgaTxGain) Range() [2]float32 {
+	return steppedGain(tg).Range()
+}
+
+// Get the gain steps that we support.
+func (tg vgaTxGain) GetGainSteps() []float32 {
+	return steppedGain(tg).GetGainSteps()
+}
+
+// String implements the sdr.GainStage interface.
+func (tg vgaTxGain) String() string {
+	return steppedGain(tg).String()
+}
+
+// SetGain implements the internal hackrfGain interface.
+func (tg vgaTxGain) SetGain(s *Sdr, gain float32) error {
+	hackrfGain := C.uint32_t(steppedGain(tg).nearestGain(gain))
+	return rvToErr(C.hackrf_set_txvga_gain(s.dev, hackrfGain))
+}
+
+// GetGain implements the internal hackrfGain interface.
+func (tg vgaTxGain) GetGain(s *Sdr) (float32, error) {
+	return 0, sdr.ErrNotSupported
+}
+
+// ifGain
+type ifGain steppedGain
+
+// Type implements the sdr.GainStage interface.
+func (ig ifGain) Type() sdr.GainStageType {
+	return steppedGain(ig).Type()
+}
+
+// Range implements the sdr.GainStage interface.
+func (ig ifGain) Range() [2]float32 {
+	return steppedGain(ig).Range()
+}
+
+// Get the gain steps that we support.
+func (ig ifGain) GetGainSteps() []float32 {
+	return steppedGain(ig).GetGainSteps()
+}
+
+// String implements the sdr.GainStage interface.
+func (ig ifGain) String() string {
+	return steppedGain(ig).String()
+}
+
+// SetGain implements the internal hackrfGain interface.
+func (ig ifGain) SetGain(s *Sdr, gain float32) error {
+	hackrfGain := C.uint32_t(steppedGain(ig).nearestGain(gain))
+	return rvToErr(C.hackrf_set_lna_gain(s.dev, hackrfGain))
+}
+
+// GetGain implements the internal hackrfGain interface.
+func (ig ifGain) GetGain(s *Sdr) (float32, error) {
+	return 0, sdr.ErrNotSupported
+}
+
+// ampGain
+type ampGain steppedGain
+
+// Type implements the sdr.GainStage interface.
+func (ag ampGain) Type() sdr.GainStageType {
+	return steppedGain(ag).Type()
+}
+
+// Range implements the sdr.GainStage interface.
+func (ag ampGain) Range() [2]float32 {
+	return steppedGain(ag).Range()
+}
+
+// Get the gain steps that we support.
+func (ag ampGain) GetGainSteps() []float32 {
+	return steppedGain(ag).GetGainSteps()
+}
+
+// String implements the sdr.GainStage interface.
+func (ag ampGain) String() string {
+	return steppedGain(ag).String()
+}
+
+// SetGain implements the internal hackrfGain interface.
+func (ag ampGain) SetGain(s *Sdr, gain float32) error {
+	onOff := C.uint32_t(steppedGain(ag).nearestGain(gain))
+	var enabledU8 C.uint8_t = 0
+	if onOff != 0 {
+		enabledU8 = 1
+	}
+	return rvToErr(C.hackrf_set_amp_enable(s.dev, enabledU8))
+}
+
+// GetGain implements the internal hackrfGain interface.
+func (ag ampGain) GetGain(s *Sdr) (float32, error) {
+	return 0, sdr.ErrNotSupported
+}
+
+// vim: foldmethod=marker

--- a/hackrf/hackrf.go
+++ b/hackrf/hackrf.go
@@ -1,0 +1,236 @@
+// {{{ Copyright (c) Paul R. Tagliamonte <paul@k3xec.com>, 2020-2021
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. }}}
+
+package hackrf
+
+// #cgo pkg-config: libhackrf
+//
+// #include <libhackrf/hackrf.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"hz.tools/rf"
+	"hz.tools/sdr"
+)
+
+var (
+	hasInit         bool = false
+	usbBoardMapping      = map[uint32]Board{
+		0x604B: BoardJawbreaker,
+		0x6089: BoardHackRfOne,
+		0xFFFF: BoardInvalid,
+	}
+)
+
+func checkInit() error {
+	if !hasInit {
+		return fmt.Errorf("hackrf: Init was not called")
+	}
+	return nil
+}
+
+func rvToErr(rv C.int) error {
+	if rv != 0 {
+		errString := C.GoString(C.hackrf_error_name(int32(rv)))
+		return fmt.Errorf("hackrf: %s (code: %d)", errString, int32(rv))
+	}
+	return nil
+}
+
+// Board represents the type of HackRf hardware.
+type Board uint8
+
+var (
+	// BoardInvalid indicates the board that relates to the request is invalid.
+	BoardInvalid Board = 0xFF
+
+	// BoardJawbreaker represents a Jawbreaker, the beta test hardware platform
+	// for the HackRf.
+	BoardJawbreaker Board = 1
+
+	// BoardHackRfOne represents the production HackRf One.
+	BoardHackRfOne Board = 2
+)
+
+// String will return a human readable string representing the hardware.
+func (b Board) String() string {
+	switch b {
+	case BoardJawbreaker:
+		return "Jawbreaker"
+	case BoardHackRfOne:
+		return "HackRf One"
+	case BoardInvalid:
+		return "invalid"
+	default:
+		return "unknown"
+	}
+}
+
+// List will return the sdr.HardwareInfo for all HackRF devices that are
+// plugged into this system.
+func List() ([]sdr.HardwareInfo, error) {
+	if err := checkInit(); err != nil {
+		return nil, err
+	}
+
+	list := C.hackrf_device_list()
+	defer C.hackrf_device_list_free(list)
+
+	count := int(list.devicecount)
+	usbBoardIds := (*[1 << 30]C.enum_hackrf_usb_board_id)(unsafe.Pointer(list.usb_board_ids))[:count]
+	serials := (*[1 << 30]*C.char)(unsafe.Pointer(list.serial_numbers))[:count]
+
+	ret := []sdr.HardwareInfo{}
+	for i := 0; i < count; i++ {
+		ret = append(ret, sdr.HardwareInfo{
+			Serial:       C.GoString(serials[i]),
+			Manufacturer: "Great Scott Gadgets",
+			Product:      Board(usbBoardMapping[usbBoardIds[i]]).String(),
+		})
+	}
+
+	return ret, nil
+}
+
+// Init *must* be called before the HackRF can be used. Attempting to use the
+// HackRF or calling any HackRF functions may result in error if done before
+// invoking Init.
+func Init() error {
+	err := rvToErr(C.hackrf_init())
+	if err == nil {
+		hasInit = true
+	}
+	return err
+}
+
+// Exit will clean up after Init, and should be called when the process is
+// shutting down, or otherwise done with the HackRF.
+func Exit() error {
+	return rvToErr(C.hackrf_exit())
+}
+
+// Version will return the HackRF library version and release.
+func Version() (string, string) {
+	return C.GoString(C.hackrf_library_version()), C.GoString(C.hackrf_library_release())
+}
+
+// Open will open the first HackRF on the system.
+func Open() (*Sdr, error) {
+	var dev *C.hackrf_device
+
+	if err := rvToErr(C.hackrf_open(&dev)); err != nil {
+		return nil, err
+	}
+
+	return &Sdr{
+		dev: dev,
+	}, nil
+}
+
+// Sdr implements the sdr.Sdr interface for the HackRF One.
+type Sdr struct {
+	dev *C.hackrf_device
+
+	sampleRate      uint
+	centerFrequency rf.Hz
+}
+
+// Close implements the sdr.Sdr interface
+func (s *Sdr) Close() error {
+	return rvToErr(C.hackrf_close(s.dev))
+}
+
+// SetCenterFrequency implements the sdr.Sdr interface
+func (s *Sdr) SetCenterFrequency(freq rf.Hz) error {
+	err := rvToErr(C.hackrf_set_freq(
+		s.dev,
+		C.uint64_t(freq),
+	))
+	if err != nil {
+		return err
+	}
+	s.centerFrequency = freq
+	return nil
+}
+
+// GetCenterFrequency implements the sdr.Sdr interface
+func (s *Sdr) GetCenterFrequency() (rf.Hz, error) {
+	return s.centerFrequency, nil
+}
+
+// SetAutomaticGain implements the sdr.Sdr interface
+func (s *Sdr) SetAutomaticGain(bool) error {
+	return sdr.ErrNotSupported
+}
+
+// SetSampleRate implements the sdr.Sdr interface
+func (s *Sdr) SetSampleRate(sampleRate uint) error {
+	err := rvToErr(C.hackrf_set_sample_rate(s.dev, C.double(sampleRate)))
+	if err != nil {
+		return err
+	}
+	s.sampleRate = sampleRate
+	return nil
+}
+
+// GetSampleRate implements the sdr.Sdr interface
+func (s *Sdr) GetSampleRate() (uint, error) {
+	return s.sampleRate, nil
+}
+
+// SampleFormat implements the sdr.Sdr interface
+func (s *Sdr) SampleFormat() sdr.SampleFormat {
+	return sdr.SampleFormatI8
+}
+
+// SetPPM implements the sdr.Sdr interface
+func (s *Sdr) SetPPM(int) error {
+	return sdr.ErrNotSupported
+}
+
+// HardwareInfo implements the sdr.Sdr interface
+func (s *Sdr) HardwareInfo() sdr.HardwareInfo {
+	var (
+		partid = C.read_partid_serialno_t{}
+		board  C.uint8_t
+	)
+
+	C.hackrf_board_partid_serialno_read(s.dev, &partid)
+	C.hackrf_board_id_read(s.dev, &board)
+
+	serial := fmt.Sprintf(
+		"%08x%08x%08x%08x",
+		partid.serial_no[0],
+		partid.serial_no[1],
+		partid.serial_no[2],
+		partid.serial_no[3],
+	)
+
+	return sdr.HardwareInfo{
+		Serial:       serial,
+		Product:      Board(board).String(),
+		Manufacturer: "Great Scott Gadgets",
+	}
+}
+
+// vim: foldmethod=marker

--- a/hackrf/rx.go
+++ b/hackrf/rx.go
@@ -1,0 +1,125 @@
+// {{{ Copyright (c) Paul R. Tagliamonte <paul@k3xec.com>, 2020
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. }}}
+
+package hackrf
+
+// #cgo pkg-config: libhackrf
+//
+// #include <libhackrf/hackrf.h>
+//
+// extern int hackrf_rx_callback(hackrf_transfer* transfer);
+import "C"
+
+import (
+	"log"
+	"sync"
+	"unsafe"
+
+	"github.com/mattn/go-pointer"
+
+	"hz.tools/sdr"
+)
+
+type rxCallbackState struct {
+	pipeReader sdr.PipeReader
+	pipeWriter sdr.PipeWriter
+}
+
+//export hackrfRxCallback
+func hackrfRxCallback(transfer *C.hackrf_transfer) int {
+	state := pointer.Restore(transfer.rx_ctx).(*rxCallbackState)
+
+	// First, we need to load the incoming bytes from HackRF to a Go
+	// []byte type.
+	//
+	// Let's first compute bounds to avoid doing weirdo stuff later.
+	bufSize := int(transfer.valid_length)
+	if bufSize%2 != 0 {
+		log.Printf("hackrf: rx: bufSize is misaligned")
+		bufSize--
+	}
+	bufIQLength := bufSize / sdr.SampleFormatI8.Size()
+
+	buf := C.GoBytes(unsafe.Pointer(transfer.buffer), C.int(bufSize))
+
+	// TODO(paultag): use a pool?
+	//
+	// Now let's allocate a new sdr.Samples, copy the bytes from the
+	// []byte above directly onto the IQ samples, and write that into the
+	// pipe.
+	samples := make(sdr.SamplesI8, bufIQLength)
+
+	if copy(sdr.MustUnsafeSamplesAsBytes(samples), buf) != bufSize {
+		log.Printf("hackrf: rx: copy() didn't move the whole window over")
+		return -1
+	}
+
+	i, err := state.pipeWriter.Write(samples)
+	if err != nil {
+		log.Printf("hackrf: rx: write error %s", err)
+		return -1
+	}
+
+	if i != bufIQLength {
+		log.Printf("hackrf: rx: short write")
+		return -1
+	}
+
+	return 0
+}
+
+// StartRx implements the sdr.Sdr interface.
+func (s *Sdr) StartRx() (sdr.ReadCloser, error) {
+	pipeReader, pipeWriter := sdr.Pipe(s.sampleRate, sdr.SampleFormatI8)
+
+	state := pointer.Save(&rxCallbackState{
+		pipeReader: pipeReader,
+		pipeWriter: pipeWriter,
+	})
+
+	if err := rvToErr(C.hackrf_start_rx(
+		s.dev,
+		C.hackrf_sample_block_cb_fn(C.hackrf_rx_callback),
+		state,
+	)); err != nil {
+		return nil, err
+	}
+
+	var (
+		lock   = &sync.Mutex{}
+		closed bool
+	)
+	return sdr.ReaderWithCloser(pipeReader, func() error {
+		lock.Lock()
+		defer lock.Unlock()
+
+		if closed {
+			return nil
+		}
+
+		defer pointer.Unref(state)
+		err := rvToErr(C.hackrf_stop_rx(s.dev))
+		pipeWriter.Close()
+		closed = true
+		return err
+	}), nil
+}
+
+// vim: foldmethod=marker

--- a/hackrf/rx_callback.go
+++ b/hackrf/rx_callback.go
@@ -1,0 +1,31 @@
+// {{{ Copyright (c) Paul R. Tagliamonte <paul@k3xec.com>, 2020
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. }}}
+
+package hackrf
+
+// #include <libhackrf/hackrf.h>
+//
+// extern int hackrfRxCallback(hackrf_transfer* transfer);
+// int hackrf_rx_callback(hackrf_transfer* transfer) {
+//   return hackrfRxCallback(transfer);
+// }
+import "C"
+
+// vim: foldmethod=marker

--- a/hackrf/tx.go
+++ b/hackrf/tx.go
@@ -1,0 +1,127 @@
+// {{{ Copyright (c) Paul R. Tagliamonte <paul@k3xec.com>, 2020-2021
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. }}}
+
+package hackrf
+
+// #cgo pkg-config: libhackrf
+//
+// #include <libhackrf/hackrf.h>
+//
+// extern int hackrf_tx_callback(hackrf_transfer* transfer);
+import "C"
+
+import (
+	"log"
+	"sync"
+	"unsafe"
+
+	"github.com/mattn/go-pointer"
+
+	"hz.tools/sdr"
+)
+
+type txCallbackState struct {
+	pipeReader sdr.PipeReader
+	pipeWriter sdr.PipeWriter
+}
+
+func goBytesButReally(
+	base uintptr,
+	size int,
+) []byte {
+	var b = struct {
+		base uintptr
+		len  int
+		cap  int
+	}{base, size, size}
+	return *(*[]byte)(unsafe.Pointer(&b))
+}
+
+//export hackrfTxCallback
+func hackrfTxCallback(transfer *C.hackrf_transfer) int {
+	state := pointer.Restore(transfer.tx_ctx).(*txCallbackState)
+
+	// First, we need to load the incoming bytes from HackRF to a Go
+	// []byte type.
+	//
+	// Let's first compute bounds to avoid doing weirdo stuff later.
+	bufSize := int(transfer.valid_length)
+	if bufSize%2 != 0 {
+		log.Printf("hackrf: tx: bufSize is misaligned")
+		bufSize--
+	}
+	buf := goBytesButReally(uintptr(unsafe.Pointer(transfer.buffer)), bufSize)
+	bufIQLength := bufSize / sdr.SampleFormatI8.Size()
+
+	// Now, let's grab some fresh bytes from the ole' pipe
+	samples := make(sdr.SamplesI8, bufIQLength)
+
+	_, err := sdr.ReadFull(state.pipeReader, samples)
+	if err != nil {
+		log.Printf("hackrf: tx: failed to ReadFull")
+		return -1
+	}
+
+	if copy(buf, sdr.MustUnsafeSamplesAsBytes(samples)) != bufSize {
+		log.Printf("hackrf: tx: copy() didn't move the whole window over")
+		return -1
+	}
+
+	return 0
+}
+
+// StartTx implements the sdr.Sdr interface.
+func (s *Sdr) StartTx() (sdr.WriteCloser, error) {
+	pipeReader, pipeWriter := sdr.Pipe(s.sampleRate, sdr.SampleFormatI8)
+
+	state := pointer.Save(&txCallbackState{
+		pipeReader: pipeReader,
+		pipeWriter: pipeWriter,
+	})
+
+	if err := rvToErr(C.hackrf_start_tx(
+		s.dev,
+		C.hackrf_sample_block_cb_fn(C.hackrf_tx_callback),
+		state,
+	)); err != nil {
+		return nil, err
+	}
+
+	var (
+		lock   = &sync.Mutex{}
+		closed bool
+	)
+	return sdr.WriterWithCloser(pipeWriter, func() error {
+		lock.Lock()
+		defer lock.Unlock()
+
+		if closed {
+			return nil
+		}
+
+		defer pointer.Unref(state)
+		pipeWriter.Close()
+		err := rvToErr(C.hackrf_stop_tx(s.dev))
+		closed = true
+		return err
+	}), nil
+}
+
+// vim: foldmethod=marker

--- a/hackrf/tx_callback.go
+++ b/hackrf/tx_callback.go
@@ -1,0 +1,31 @@
+// {{{ Copyright (c) Paul R. Tagliamonte <paul@k3xec.com>, 2020
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. }}}
+
+package hackrf
+
+// #include <libhackrf/hackrf.h>
+//
+// extern int hackrfTxCallback(hackrf_transfer* transfer);
+// int hackrf_tx_callback(hackrf_transfer* transfer) {
+//   return hackrfTxCallback(transfer);
+// }
+import "C"
+
+// vim: foldmethod=marker


### PR DESCRIPTION
This is a mostly complete overhaul of the old driver, with some massive
cleanup. This uses the int8 sample format. This is not super battle
tested but it contains enough to be worth adding back into main.