### PR TITLE
Add in support for the Pluto Loopback BIST

### DIFF
--- a/pluto/iio/device.go
+++ b/pluto/iio/device.go
@@ -28,6 +28,7 @@ import "C"
 
 import (
 	"fmt"
+	"syscall"
 	"unsafe"
 )
 
@@ -67,6 +68,22 @@ type Device struct {
 // String will return the name of the Device.
 func (d Device) String() string {
 	return d.name
+}
+
+// WriteDebugInt64 will write a debug int64 chanel attribute to the backing device.
+func (d Device) WriteDebugInt64(name string, value int64) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	errno := C.iio_device_debug_attr_write_longlong(
+		d.handle,
+		cName,
+		C.longlong(value),
+	)
+	if errno == 0 {
+		return nil
+	}
+	return syscall.Errno(-errno)
 }
 
 // vim: foldmethod=marker

--- a/pluto/pluto.go
+++ b/pluto/pluto.go
@@ -134,6 +134,24 @@ func Open(endpoint string) (*Sdr, error) {
 	}, nil
 }
 
+// SetLoopback will set BIST Loopback to send TX data to the RX port, to do
+// things like determine the phase offset between RX and TX.
+func (s *Sdr) SetLoopback(b bool) error {
+	// s.phy
+	// loopback
+
+	// 0  Disable
+	// 1  Digital TX → Digital RX
+	// 2  RF RX → RF TX
+
+	var v int64 = 0
+	if b {
+		v = 1
+	}
+
+	return s.phy.WriteDebugInt64("loopback", v)
+}
+
 // Close implements the sdr.Sdr interface.
 func (s *Sdr) Close() error {
 	return nil


### PR DESCRIPTION
This will route TX samples to the RX channel in hardware. This allows
for some interesting observation of hardware state, such as phase or
clock offsets between rx and tx.