### PR TITLE
Add in a new "Yikes" package, for bad things.

### DIFF
--- a/TODO
+++ b/TODO
@@ -7,8 +7,6 @@
 
  - SetCenterFrequency channel param (rx/tx, 1, 2, 3)
 
- - Refactor hackrf/lime goBytesReally to an unsafe helper. Limit the gross.
-
  - SIMD
    - Unity Gain
    - Downsample

--- a/hackrf/tx.go
+++ b/hackrf/tx.go
@@ -35,23 +35,12 @@ import (
 	"github.com/mattn/go-pointer"
 
 	"hz.tools/sdr"
+	"hz.tools/sdr/internal/yikes"
 )
 
 type txCallbackState struct {
 	pipeReader sdr.PipeReader
 	pipeWriter sdr.PipeWriter
-}
-
-func goBytesButReally(
-	base uintptr,
-	size int,
-) []byte {
-	var b = struct {
-		base uintptr
-		len  int
-		cap  int
-	}{base, size, size}
-	return *(*[]byte)(unsafe.Pointer(&b))
 }
 
 //export hackrfTxCallback
@@ -67,7 +56,7 @@ func hackrfTxCallback(transfer *C.hackrf_transfer) int {
 		log.Printf("hackrf: tx: bufSize is misaligned")
 		bufSize--
 	}
-	buf := goBytesButReally(uintptr(unsafe.Pointer(transfer.buffer)), bufSize)
+	buf := yikes.GoBytes(uintptr(unsafe.Pointer(transfer.buffer)), bufSize)
 	bufIQLength := bufSize / sdr.SampleFormatI8.Size()
 
 	// Now, let's grab some fresh bytes from the ole' pipe

--- a/internal/yikes/bytes.go
+++ b/internal/yikes/bytes.go
@@ -1,0 +1,43 @@
+// {{{ Copyright (c) Paul R. Tagliamonte <paul@k3xec.com>, 2020-2021
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE. }}}
+
+package yikes
+
+import (
+	"unsafe"
+)
+
+// GoBytes works like C.GoBytes, but it allows for mutating the C byte array
+// from Go. This is wildly unsafe, and something that needs to be very carefully
+// applied to problems, but is generally going to be used at i/o boundaries,
+// specifically on the tx paths.
+func GoBytes(
+	base uintptr,
+	size int,
+) []byte {
+	var b = struct {
+		base uintptr
+		len  int
+		cap  int
+	}{base, size, size}
+	return *(*[]byte)(unsafe.Pointer(&b))
+}
+
+// vim: foldmethod=marker

--- a/lime/tx.go
+++ b/lime/tx.go
@@ -30,19 +30,8 @@ import (
 	"unsafe"
 
 	"hz.tools/sdr"
+	"hz.tools/sdr/internal/yikes"
 )
-
-func goBytesButReally(
-	base uintptr,
-	size int,
-) []byte {
-	var b = struct {
-		base uintptr
-		len  int
-		cap  int
-	}{base, size, size}
-	return *(*[]byte)(unsafe.Pointer(&b))
-}
 
 // StartTx implements the sdr.Transmitter interface.
 func (s *Sdr) StartTx() (sdr.WriteCloser, error) {
@@ -96,7 +85,7 @@ func (s *Sdr) StartTx() (sdr.WriteCloser, error) {
 		return nil, err
 	}
 	txBufferBytes := sdr.MustUnsafeSamplesAsBytes(txBuffer)
-	txBufferCBytes := goBytesButReally(
+	txBufferCBytes := yikes.GoBytes(
 		uintptr(unsafe.Pointer(txBufferC)),
 		txBufferSizeC,
 	)

--- a/uhd/tx.go
+++ b/uhd/tx.go
@@ -32,6 +32,7 @@ import (
 	"unsafe"
 
 	"hz.tools/sdr"
+	"hz.tools/sdr/internal/yikes"
 )
 
 // writeCloser contains all the allocated structs to be used by the writeer
@@ -138,7 +139,7 @@ func (rc *writeCloser) run() {
 		}
 		cn = C.size_t(n)
 
-		ciqGB := goBytesButReally(uintptr(unsafe.Pointer(ciq)), iqSize)
+		ciqGB := yikes.GoBytes(uintptr(unsafe.Pointer(ciq)), iqSize)
 		copy(ciqGB, sdr.MustUnsafeSamplesAsBytes(iq))
 
 		if rvToError(C.uhd_tx_streamer_send(
@@ -149,18 +150,6 @@ func (rc *writeCloser) run() {
 			return
 		}
 	}
-}
-
-func goBytesButReally(
-	base uintptr,
-	size int,
-) []byte {
-	var b = struct {
-		base uintptr
-		len  int
-		cap  int
-	}{base, size, size}
-	return *(*[]byte)(unsafe.Pointer(&b))
 }
 
 // StartTx implements the sdr.Sdr interface.


### PR DESCRIPTION
This refactors out some of the worst helpers I've written, stuff like
treating a C memory allocation as a Go byte slice (gross) to allow for
Go to mutate the C buffer.

Additional "yikes" may be placed in here as time goes on. Please don't
copy any of these out :)